### PR TITLE
Enable vux-loader to support webpack2 loader with query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -253,17 +253,19 @@ module.exports.merge = function (oldConfig, vuxConfig) {
     let hasAppendVuxLoader = false
     config.module[loaderKey].forEach(function (rule) {
       if (rule.loader === 'vue' || rule.loader === 'vue-loader') {
-        if (!isWebpack2 || (isWebpack2 && !rule.options)) {
+        if (!isWebpack2 || (isWebpack2 && !rule.options && !rule.query)) {
           rule.loader = loaderString
-        } else if (isWebpack2 && rule.options) {
+        } else if (isWebpack2 && (rule.options || rule.query)) {
           delete rule.loader
           rule.use = [
          'vux-loader',
             {
               loader: 'vue-loader',
-              options: rule.options
+              options: rule.options,
+              query: rule.query
          }]
          delete rule.options
+         delete rule.query
         }
         hasAppendVuxLoader = true
       }
@@ -281,7 +283,13 @@ module.exports.merge = function (oldConfig, vuxConfig) {
    */
   config.module[loaderKey].forEach(function (rule) {
     if (rule.loader === 'babel' || rule.loader === 'babel-loader' || (/babel/.test(rule.loader) && !/!/.test(rule.loader))) {
-      rule.loader = 'babel-loader!' + jsLoader
+      if (isWebpack2 && rule.query) {
+        rule.use = [jsLoader, {loader: 'babel-loader', query: rule.query}]
+        delete rule.query
+        delete rule.loader
+      } else {
+        rule.loader = 'babel-loader!' + jsLoader
+      }
     }
   })
 


### PR DESCRIPTION
这个PR主要是为了解决nuxt.js的webpack2问题。实例配置如下：
nuxt.config.js
````
    extend(config) {
      vuxLoader.merge(config, {
        options: {
          isWebpack2: true
        },
        plugins: [{
          name: 'vux-ui'
        }, {
          name: 'duplicate-style'
        }]
      })
    }
````