### PR TITLE
bug fix: Each "*.vue" file is loaded twice in runtime. The root reaso…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -622,9 +622,7 @@ const _addScriptLoader = function (content, SCRIPT) {
       return item
     })
     content = loaders.join('!')
-  }
-
-  if (content.indexOf('export * from') !== -1) {
+  } else if (content.indexOf('export * from') !== -1) {
     let loaders = content.split('!')
     loaders = loaders.map(function (item) {
       if (item === 'babel-loader') {


### PR DESCRIPTION
bug fix: Each "*.vue" file is loaded twice in runtime. The root reason is that the same ".vue" file is referenced twice with different ref path.

- The 1st ref path: ./node_modules/babel-loader/lib/index.js!./node_modules/vux-loader/src/script-loader.js!./node_modules/vux-loader/src/script-loader.js!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./src/components/VuxDemo.vue
- The 2nd ref path: ./node_modules/babel-loader/lib/index.js!./node_modules/vux-loader/src/script-loader.js!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./src/components/VuxDemo.vue

As you see, there are two ref paths for the identical "*.vue" file (e.g. ./src/components/VuxDemo.vue). What's worse, there are two fragments "!./node_modules/vux-loader/src/script-loader.js" in the first one, which is erroneous and brings about the module-cache failure.

My change fixes it.